### PR TITLE
Fix settings persistence and documentation entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ focus/
 ├── reset-password.html      # Placeholder for resetting a user’s password via a secure link or token (future use)
 ├── script.js                # Core logic for the Pomodoro timer, session transitions, XP tracking, and UI updates
 ├── style.css                # Main stylesheet: handles layout, color themes, responsiveness, and animations
-├── read.md                  # this is the read file where you could read about the documentation
-└── docs/                    # This has all of the document images for the read file 
+└── docs/                    # Documentation images used in the README
 ```
 
 ---

--- a/script.js
+++ b/script.js
@@ -151,6 +151,17 @@ if (window.location.pathname.endsWith('index.html') || window.location.pathname 
   });
 })();
 
+function readSavedSettings() {
+  const savedSettings = localStorage.getItem('userSettings');
+  if (!savedSettings) return null;
+  try {
+    return JSON.parse(savedSettings);
+  } catch (error) {
+    console.warn('Unable to parse saved settings.', error);
+    return null;
+  }
+}
+
 // --- Motivation Quote Randomizer + Typewriter Effect ---
 document.addEventListener('DOMContentLoaded', function() {
   // Dynamic EXP Bar for Dashboard
@@ -406,11 +417,9 @@ document.addEventListener('DOMContentLoaded', function() {
   // On DOMContentLoaded, load settings from localStorage
   if (window.location.pathname.endsWith('settings.html')) {
     document.addEventListener('DOMContentLoaded', function() {
-      const savedSettings = localStorage.getItem('userSettings');
+      const savedSettings = readSavedSettings();
       if (savedSettings) {
-        try {
-          setSettingsToForm(JSON.parse(savedSettings));
-        } catch (e) {}
+        setSettingsToForm(savedSettings);
       }
     });
   }
@@ -451,6 +460,9 @@ document.addEventListener('DOMContentLoaded', function() {
         // Save all settings to localStorage
         const settings = getSettingsFromForm();
         localStorage.setItem('userSettings', JSON.stringify(settings));
+        if (settings.profilePhoto) {
+          localStorage.setItem('profilePhoto', settings.profilePhoto);
+        }
         alert('Settings saved successfully!');
       });
     }
@@ -459,9 +471,9 @@ document.addEventListener('DOMContentLoaded', function() {
       cancelButton.addEventListener('click', function(e) {
         e.preventDefault();
         // Reset form to saved values
-        const savedSettings = localStorage.getItem('userSettings');
+        const savedSettings = readSavedSettings();
         if (savedSettings) {
-          setSettingsToForm(JSON.parse(savedSettings));
+          setSettingsToForm(savedSettings);
         }
         alert('Changes cancelled.');
       });
@@ -498,12 +510,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const photoPreview = document.getElementById('profile-photo-preview');
     const uploadBtn = document.getElementById('upload-photo-btn');
     // Load photo from settings, not localStorage directly
-    const savedSettings = localStorage.getItem('userSettings');
+    const savedSettings = readSavedSettings();
     if (savedSettings && photoPreview) {
-      try {
-        const settings = JSON.parse(savedSettings);
-        if (settings.profilePhoto) photoPreview.src = settings.profilePhoto;
-      } catch (e) {}
+      if (savedSettings.profilePhoto) photoPreview.src = savedSettings.profilePhoto;
     }
     if (uploadBtn && photoInput && photoPreview) {
       uploadBtn.addEventListener('click', function() {
@@ -563,7 +572,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
 document.addEventListener('DOMContentLoaded', function() {
   const dashboardPhoto = document.getElementById('dashboard-profile-photo');
-  const savedPhoto = localStorage.getItem('profilePhoto');
+  const savedSettings = readSavedSettings();
+  const savedPhoto = savedSettings?.profilePhoto || localStorage.getItem('profilePhoto');
   if (dashboardPhoto && savedPhoto) {
     dashboardPhoto.src = savedPhoto;
   }


### PR DESCRIPTION
### Motivation
- Settings loading was brittle and could throw or fail to populate the UI when `userSettings` was missing or malformed, and profile photos were not reliably shown on the dashboard.
- Improve robustness and developer clarity by centralizing settings parsing and avoiding repeated `JSON.parse` calls across `script.js`.
- Clean up the README to remove a reference to a missing file and clarify the `docs/` entry.

### Description
- Added a shared helper `readSavedSettings()` that safely reads and `JSON.parse`s `localStorage` `userSettings` and returns `null` on failure.
- Replaced multiple direct `localStorage.getItem('userSettings')` + `JSON.parse` usages with calls to `readSavedSettings()` when loading settings, cancelling edits, and initializing the profile preview.
- Persist `profilePhoto` to `localStorage` when saving settings and prefer `savedSettings?.profilePhoto` (falling back to the older `profilePhoto` key) when populating the dashboard image.
- Updated `README.md` to remove the non-existent `read.md` reference and reword the `docs/` line for clarity.

### Testing
- No automated tests were run for these static frontend changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811b97dbc8832eb96993dff3962e2c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile photos are now automatically saved and persisted with your account settings.

* **Bug Fixes**
  * Enhanced stability and reliability when loading and recovering saved settings across different pages.

* **Documentation**
  * Updated project structure documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->